### PR TITLE
Add Blake3 as the default hasher for Plonk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.1"
 edition = "2021"
 
 [workspace.dependencies]
-blake2 = "0.10.6"
 educe = "0.5.0"
 hex = "0.4.3"
 itertools = "0.12.0"
@@ -17,6 +16,7 @@ bytemuck = "1.14.3"
 tracing = "0.1.40"
 indexmap = "2.2.6"
 sha2 = "0.10.8"
+blake3 = "1.5.5"
 
 [profile.bench]
 codegen-units = 1

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -27,6 +27,7 @@ rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sha2.workspace = true
 indexmap.workspace = true
+blake3.workspace = true
 
 [dev-dependencies]
 aligned = "0.4.2"

--- a/crates/prover/src/core/backend/cpu/blake3.rs
+++ b/crates/prover/src/core/backend/cpu/blake3.rs
@@ -1,0 +1,24 @@
+use itertools::Itertools;
+
+use crate::core::backend::CpuBackend;
+use crate::core::fields::m31::BaseField;
+use crate::core::vcs::blake3_hash::Blake3Hash;
+use crate::core::vcs::blake3_merkle::Blake3MerkleHasher;
+use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
+
+impl MerkleOps<Blake3MerkleHasher> for CpuBackend {
+    fn commit_on_layer(
+        log_size: u32,
+        prev_layer: Option<&Vec<Blake3Hash>>,
+        columns: &[&Vec<BaseField>],
+    ) -> Vec<Blake3Hash> {
+        (0..(1 << log_size))
+            .map(|i| {
+                Blake3MerkleHasher::hash_node(
+                    prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
+                    &columns.iter().map(|column| column[i]).collect_vec(),
+                )
+            })
+            .collect()
+    }
+}

--- a/crates/prover/src/core/backend/cpu/mod.rs
+++ b/crates/prover/src/core/backend/cpu/mod.rs
@@ -1,4 +1,5 @@
 mod accumulation;
+mod blake3;
 mod circle;
 mod fri;
 mod grind;
@@ -15,6 +16,7 @@ use crate::core::fields::Field;
 use crate::core::lookups::mle::Mle;
 use crate::core::poly::circle::{CircleEvaluation, CirclePoly};
 use crate::core::utils::bit_reverse;
+use crate::core::vcs::blake3_merkle::Blake3MerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
 use crate::core::vcs::sha256_merkle::Sha256MerkleChannel;
@@ -24,6 +26,7 @@ pub struct CpuBackend;
 
 impl Backend for CpuBackend {}
 impl BackendForChannel<Sha256MerkleChannel> for CpuBackend {}
+impl BackendForChannel<Blake3MerkleChannel> for CpuBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for CpuBackend {}
 

--- a/crates/prover/src/core/backend/simd/blake3.rs
+++ b/crates/prover/src/core/backend/simd/blake3.rs
@@ -1,0 +1,41 @@
+use itertools::Itertools;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use crate::core::backend::simd::column::BaseColumn;
+use crate::core::backend::simd::SimdBackend;
+use crate::core::backend::{Column, ColumnOps};
+use crate::core::vcs::blake3_hash::Blake3Hash;
+use crate::core::vcs::blake3_merkle::Blake3MerkleHasher;
+use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
+
+impl ColumnOps<Blake3Hash> for SimdBackend {
+    type Column = Vec<Blake3Hash>;
+
+    fn bit_reverse_column(_column: &mut Self::Column) {
+        unimplemented!()
+    }
+}
+
+// TODO(BWS): not simd at all
+impl MerkleOps<Blake3MerkleHasher> for SimdBackend {
+    fn commit_on_layer(
+        log_size: u32,
+        prev_layer: Option<&Vec<Blake3Hash>>,
+        columns: &[&BaseColumn],
+    ) -> Vec<Blake3Hash> {
+        #[cfg(not(feature = "parallel"))]
+        let iter = 0..1 << log_size;
+
+        #[cfg(feature = "parallel")]
+        let iter = (0..1 << log_size).into_par_iter();
+
+        iter.map(|i| {
+            Blake3MerkleHasher::hash_node(
+                prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
+                &columns.iter().map(|column| column.at(i)).collect_vec(),
+            )
+        })
+        .collect()
+    }
+}

--- a/crates/prover/src/core/backend/simd/grind.rs
+++ b/crates/prover/src/core/backend/simd/grind.rs
@@ -1,4 +1,5 @@
 use super::SimdBackend;
+use crate::core::channel::blake3::Blake3Channel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::channel::Poseidon252Channel;
 use crate::core::channel::{Channel, Sha256Channel};
@@ -6,6 +7,20 @@ use crate::core::proof_of_work::GrindOps;
 
 impl GrindOps<Sha256Channel> for SimdBackend {
     fn grind(channel: &Sha256Channel, pow_bits: u32) -> u64 {
+        let mut nonce = 0;
+        loop {
+            let mut channel = channel.clone();
+            channel.mix_nonce(nonce);
+            if channel.trailing_zeros() >= pow_bits {
+                return nonce;
+            }
+            nonce += 1;
+        }
+    }
+}
+
+impl GrindOps<Blake3Channel> for SimdBackend {
+    fn grind(channel: &Blake3Channel, pow_bits: u32) -> u64 {
         let mut nonce = 0;
         loop {
             let mut channel = channel.clone();

--- a/crates/prover/src/core/backend/simd/mod.rs
+++ b/crates/prover/src/core/backend/simd/mod.rs
@@ -1,10 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 use super::{Backend, BackendForChannel};
+use crate::core::vcs::blake3_merkle::Blake3MerkleChannel;
 use crate::core::vcs::sha256_merkle::Sha256MerkleChannel;
 
 pub mod accumulation;
 pub mod bit_reverse;
+pub mod blake3;
 pub mod circle;
 pub mod cm31;
 pub mod column;
@@ -26,3 +28,4 @@ pub struct SimdBackend;
 
 impl Backend for SimdBackend {}
 impl BackendForChannel<Sha256MerkleChannel> for SimdBackend {}
+impl BackendForChannel<Blake3MerkleChannel> for SimdBackend {}

--- a/crates/prover/src/core/channel/mod.rs
+++ b/crates/prover/src/core/channel/mod.rs
@@ -9,6 +9,10 @@ pub use poseidon252::Poseidon252Channel;
 pub mod sha256;
 pub use sha256::Sha256Channel;
 
+use crate::core::fields::m31::M31;
+
+pub mod blake3;
+
 pub const EXTENSION_FELTS_PER_HASH: usize = 2;
 
 #[derive(Clone, Default)]
@@ -51,4 +55,15 @@ pub trait MerkleChannel: Default {
     type C: Channel;
     type H: MerkleHasher;
     fn mix_root(channel: &mut Self::C, root: <Self::H as MerkleHasher>::Hash);
+}
+
+pub(crate) fn extract_common(hash: &[u8]) -> M31 {
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&hash[0..4]);
+
+    let mut res = u32::from_le_bytes(bytes);
+    res &= 0x7fffffff;
+    res %= (1 << 31) - 1;
+
+    M31::from(res)
 }

--- a/crates/prover/src/core/vcs/blake3_hash.rs
+++ b/crates/prover/src/core/vcs/blake3_hash.rs
@@ -1,0 +1,130 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+// Wrapper for the blake3 hash type.
+#[repr(align(32))]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+pub struct Blake3Hash(pub(crate) [u8; 32]);
+
+impl From<Blake3Hash> for Vec<u8> {
+    fn from(value: Blake3Hash) -> Self {
+        Vec::from(value.0)
+    }
+}
+
+impl From<Vec<u8>> for Blake3Hash {
+    fn from(value: Vec<u8>) -> Self {
+        Self(
+            value
+                .try_into()
+                .expect("Failed converting Vec<u8> to Blake3Hash type"),
+        )
+    }
+}
+
+impl From<&[u8]> for Blake3Hash {
+    fn from(value: &[u8]) -> Self {
+        Self(
+            value
+                .try_into()
+                .expect("Failed converting &[u8] to Blake3Hash type"),
+        )
+    }
+}
+
+impl AsRef<[u8]> for Blake3Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Blake3Hash> for [u8; 32] {
+    fn from(value: Blake3Hash) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for Blake3Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for Blake3Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Blake3Hash as fmt::Display>::fmt(self, f)
+    }
+}
+
+impl super::hash::Hash for Blake3Hash {}
+
+// Wrapper for the blake3 hashing functionalities.
+#[derive(Clone, Debug, Default)]
+pub struct Blake3Hasher {
+    state: blake3::Hasher,
+}
+
+impl Blake3Hasher {
+    pub fn new() -> Self {
+        Self {
+            state: blake3::Hasher::new(),
+        }
+    }
+
+    pub fn update(&mut self, data: &[u8]) {
+        self.state.update(data);
+    }
+
+    pub fn finalize(self) -> Blake3Hash {
+        Blake3Hash(self.state.finalize().into())
+    }
+
+    pub fn concat_and_hash(v1: &Blake3Hash, v2: &Blake3Hash) -> Blake3Hash {
+        let mut hasher = Self::new();
+        hasher.update(v1.as_ref());
+        hasher.update(v2.as_ref());
+        hasher.finalize()
+    }
+
+    pub fn hash(data: &[u8]) -> Blake3Hash {
+        let mut hasher = Self::new();
+        hasher.update(data);
+        hasher.finalize()
+    }
+}
+
+#[cfg(test)]
+impl Blake3Hasher {
+    fn finalize_reset(&mut self) -> Blake3Hash {
+        let hash = self.state.finalize();
+        self.state.reset();
+        Blake3Hash(hash.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::vcs::blake3_hash::Blake3Hasher;
+
+    #[test]
+    fn single_hash_test() {
+        let hash_a = Blake3Hasher::hash(b"a");
+        assert_eq!(
+            hash_a.to_string(),
+            "17762fddd969a453925d65717ac3eea21320b66b54342fde15128d6caf21215f"
+        );
+    }
+
+    #[test]
+    fn hash_state_test() {
+        let mut state = Blake3Hasher::new();
+        state.update(b"a");
+        state.update(b"b");
+        let hash = state.finalize_reset();
+        let hash_empty = state.finalize();
+
+        assert_eq!(hash.to_string(), Blake3Hasher::hash(b"ab").to_string());
+        assert_eq!(hash_empty.to_string(), Blake3Hasher::hash(b"").to_string());
+    }
+}

--- a/crates/prover/src/core/vcs/blake3_merkle.rs
+++ b/crates/prover/src/core/vcs/blake3_merkle.rs
@@ -1,0 +1,220 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::channel::blake3::Blake3Channel;
+use crate::core::channel::MerkleChannel;
+use crate::core::fields::m31::BaseField;
+use crate::core::utils::bws_num_to_bytes;
+use crate::core::vcs::blake3_hash::{Blake3Hash, Blake3Hasher};
+use crate::core::vcs::ops::MerkleHasher;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize)]
+pub struct Blake3MerkleHasher;
+impl MerkleHasher for Blake3MerkleHasher {
+    type Hash = Blake3Hash;
+
+    fn hash_node(
+        children_hashes: Option<(Self::Hash, Self::Hash)>,
+        column_values: &[BaseField],
+    ) -> Self::Hash {
+        // There are three possibilities:
+        // - children only
+        // - children and column elements
+        // - column elements only
+        //
+        // They are handled as follows.
+        // - left | right (32 bytes | 32 bytes)
+        // - left | [column hash] | right (32 bytes | 32 bytes | 32 bytes)
+        // - [column hash] (32 bytes)
+
+        let column_hash = if column_values.is_empty() {
+            None
+        } else {
+            let len = column_values.len();
+
+            let mut hash = [0u8; 32];
+            let mut blake3 = blake3::Hasher::new();
+            blake3.update(&bws_num_to_bytes(column_values[len - 1]));
+            hash.copy_from_slice(blake3.finalize().as_bytes());
+
+            for i in 1..len {
+                let mut blake3 = blake3::Hasher::new();
+                blake3.update(&bws_num_to_bytes(column_values[len - 1 - i]));
+                blake3.update(&hash);
+                hash.copy_from_slice(blake3.finalize().as_bytes());
+            }
+
+            Some(hash)
+        };
+
+        let mut blake3 = blake3::Hasher::new();
+        match (children_hashes, column_hash) {
+            (Some(children_hashes), Some(column_hash)) => {
+                blake3.update(children_hashes.0.as_ref());
+                blake3.update(column_hash.as_ref());
+                blake3.update(children_hashes.1.as_ref());
+            }
+            (Some(children_hashes), None) => {
+                blake3.update(children_hashes.0.as_ref());
+                blake3.update(children_hashes.1.as_ref());
+            }
+            (None, Some(column_hash)) => {
+                blake3.update(column_hash.as_ref());
+            }
+            (None, None) => {
+                // do nothing if both are None
+            }
+        }
+
+        let mut hash_result = [0u8; 32];
+        hash_result.copy_from_slice(blake3.finalize().as_bytes());
+
+        hash_result.to_vec().into()
+    }
+}
+
+#[derive(Default)]
+pub struct Blake3MerkleChannel;
+
+impl MerkleChannel for Blake3MerkleChannel {
+    type C = Blake3Channel;
+    type H = Blake3MerkleHasher;
+
+    fn mix_root(channel: &mut Self::C, root: <Self::H as MerkleHasher>::Hash) {
+        channel.update_digest(Blake3Hasher::concat_and_hash(&root, &channel.digest()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use itertools::Itertools;
+    use num_traits::Zero;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    use crate::core::backend::CpuBackend;
+    use crate::core::fields::m31::BaseField;
+    use crate::core::vcs::blake3_hash::Blake3Hash;
+    use crate::core::vcs::blake3_merkle::Blake3MerkleHasher;
+    use crate::core::vcs::prover::{MerkleDecommitment, MerkleProver};
+    use crate::core::vcs::verifier::{MerkleVerificationError, MerkleVerifier};
+
+    type TestData = (
+        BTreeMap<u32, Vec<usize>>,
+        MerkleDecommitment<Blake3MerkleHasher>,
+        Vec<Vec<BaseField>>,
+        MerkleVerifier<Blake3MerkleHasher>,
+    );
+    fn prepare_merkle() -> TestData {
+        const N_COLS: usize = 400;
+        const N_QUERIES: usize = 7;
+        let log_size_range = 6..9;
+
+        let mut rng = SmallRng::seed_from_u64(0);
+        let log_sizes = (0..N_COLS)
+            .map(|_| rng.gen_range(log_size_range.clone()))
+            .collect_vec();
+        let cols = log_sizes
+            .iter()
+            .map(|&log_size| {
+                (0..(1 << log_size))
+                    .map(|_| BaseField::from(rng.gen_range(0..(1 << 30))))
+                    .collect_vec()
+            })
+            .collect_vec();
+        let merkle =
+            MerkleProver::<CpuBackend, Blake3MerkleHasher>::commit(cols.iter().collect_vec());
+
+        let mut queries = BTreeMap::<u32, Vec<usize>>::new();
+        for log_size in log_size_range.rev() {
+            let layer_queries = (0..N_QUERIES)
+                .map(|_| rng.gen_range(0..(1 << log_size)))
+                .sorted()
+                .dedup()
+                .collect_vec();
+            queries.insert(log_size, layer_queries);
+        }
+
+        let (values, decommitment) = merkle.decommit(queries.clone(), cols.iter().collect_vec());
+
+        let verifier = MerkleVerifier {
+            root: merkle.root(),
+            column_log_sizes: log_sizes,
+        };
+        (queries, decommitment, values, verifier)
+    }
+
+    #[test]
+    fn test_merkle_success() {
+        let (queries, decommitment, values, verifier) = prepare_merkle();
+
+        verifier.verify(queries, values, decommitment).unwrap();
+    }
+
+    #[test]
+    fn test_merkle_invalid_witness() {
+        let (queries, mut decommitment, values, verifier) = prepare_merkle();
+        decommitment.hash_witness[20] = Blake3Hash::default();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::RootMismatch
+        );
+    }
+
+    #[test]
+    fn test_merkle_invalid_value() {
+        let (queries, decommitment, mut values, verifier) = prepare_merkle();
+        values[3][6] = BaseField::zero();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::RootMismatch
+        );
+    }
+
+    #[test]
+    fn test_merkle_witness_too_short() {
+        let (queries, mut decommitment, values, verifier) = prepare_merkle();
+        decommitment.hash_witness.pop();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::WitnessTooShort
+        );
+    }
+
+    #[test]
+    fn test_merkle_column_values_too_long() {
+        let (queries, decommitment, mut values, verifier) = prepare_merkle();
+        values[3].push(BaseField::zero());
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::ColumnValuesTooLong
+        );
+    }
+
+    #[test]
+    fn test_merkle_column_values_too_short() {
+        let (queries, decommitment, mut values, verifier) = prepare_merkle();
+        values[3].pop();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::ColumnValuesTooShort
+        );
+    }
+
+    #[test]
+    fn test_merkle_witness_too_long() {
+        let (queries, mut decommitment, values, verifier) = prepare_merkle();
+        decommitment.hash_witness.push(Blake3Hash::default());
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::WitnessTooLong
+        );
+    }
+}

--- a/crates/prover/src/core/vcs/mod.rs
+++ b/crates/prover/src/core/vcs/mod.rs
@@ -10,5 +10,10 @@ pub mod sha256_merkle;
 mod utils;
 pub mod verifier;
 
+pub mod blake3_hash;
+pub mod blake3_merkle;
+
+pub mod poseidon31_hash;
+
 #[cfg(test)]
 mod test_utils;

--- a/crates/prover/src/core/vcs/poseidon31_hash.rs
+++ b/crates/prover/src/core/vcs/poseidon31_hash.rs
@@ -1,0 +1,27 @@
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::fields::m31::M31;
+
+#[repr(align(32))]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct Poseidon31Hash(pub(crate) [M31; 8]);
+
+impl From<Poseidon31Hash> for Vec<u8> {
+    fn from(value: Poseidon31Hash) -> Vec<u8> {
+        let mut res = vec![];
+        for limb in value.0.iter() {
+            res.extend(limb.0.to_le_bytes());
+        }
+        res
+    }
+}
+
+impl std::fmt::Display for Poseidon31Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Poseidon31Hash as Debug>::fmt(self, f)
+    }
+}
+
+impl super::hash::Hash for Poseidon31Hash {}

--- a/crates/prover/src/core/vcs/sha256_hash.rs
+++ b/crates/prover/src/core/vcs/sha256_hash.rs
@@ -19,7 +19,7 @@ impl From<Vec<u8>> for Sha256Hash {
         Self(
             value
                 .try_into()
-                .expect("Failed converting Vec<u8> to BWSSha256Hash type"),
+                .expect("Failed converting Vec<u8> to Sha256Hash type"),
         )
     }
 }
@@ -29,7 +29,7 @@ impl From<&[u8]> for Sha256Hash {
         Self(
             value
                 .try_into()
-                .expect("Failed converting &[u8] to BWSSha256Hash Type!"),
+                .expect("Failed converting &[u8] to Sha256Hash type"),
         )
     }
 }
@@ -105,11 +105,10 @@ impl Sha256Hasher {
 #[cfg(test)]
 mod tests {
     use super::Sha256Hasher;
-    use crate::core::vcs::sha256_hash;
 
     #[test]
     fn single_hash_test() {
-        let hash_a = sha256_hash::Sha256Hasher::hash(b"a");
+        let hash_a = Sha256Hasher::hash(b"a");
         assert_eq!(
             hash_a.to_string(),
             "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -14,6 +14,7 @@
     trait_upcasting,
     trivial_bounds
 )]
+
 pub mod constraint_framework;
 pub mod core;
 pub mod examples;


### PR DESCRIPTION
This PR adds the Blake3 as a channel and a Merkle hasher, and use it as the default for Plonk.