### PR TITLE
Move mult polynomial in Plonk from trace to constant

### DIFF
--- a/crates/prover/src/core/backend/cpu/mod.rs
+++ b/crates/prover/src/core/backend/cpu/mod.rs
@@ -6,6 +6,7 @@ mod grind;
 pub mod lookups;
 pub mod quotients;
 mod sha256;
+mod poseidon31;
 
 use std::fmt::Debug;
 
@@ -19,6 +20,7 @@ use crate::core::utils::bit_reverse;
 use crate::core::vcs::blake3_merkle::Blake3MerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
+use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleChannel;
 use crate::core::vcs::sha256_merkle::Sha256MerkleChannel;
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -27,6 +29,7 @@ pub struct CpuBackend;
 impl Backend for CpuBackend {}
 impl BackendForChannel<Sha256MerkleChannel> for CpuBackend {}
 impl BackendForChannel<Blake3MerkleChannel> for CpuBackend {}
+impl BackendForChannel<Poseidon31MerkleChannel> for CpuBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for CpuBackend {}
 

--- a/crates/prover/src/core/backend/cpu/poseidon31.rs
+++ b/crates/prover/src/core/backend/cpu/poseidon31.rs
@@ -1,0 +1,24 @@
+use itertools::Itertools;
+
+use crate::core::backend::CpuBackend;
+use crate::core::fields::m31::BaseField;
+use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
+use crate::core::vcs::poseidon31_hash::Poseidon31Hash;
+use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleHasher;
+
+impl MerkleOps<Poseidon31MerkleHasher> for CpuBackend {
+    fn commit_on_layer(
+        log_size: u32,
+        prev_layer: Option<&Vec<Poseidon31Hash>>,
+        columns: &[&Vec<BaseField>],
+    ) -> Vec<Poseidon31Hash> {
+        (0..(1 << log_size))
+            .map(|i| {
+                Poseidon31MerkleHasher::hash_node(
+                    prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
+                    &columns.iter().map(|column| column[i]).collect_vec(),
+                )
+            })
+            .collect()
+    }
+}

--- a/crates/prover/src/core/channel/poseidon31.rs
+++ b/crates/prover/src/core/channel/poseidon31.rs
@@ -7,7 +7,7 @@ use crate::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
 
 #[derive(Clone, Default)]
 pub struct Poseidon31Channel {
-    sponge: Poseidon31Sponge,
+    pub sponge: Poseidon31Sponge,
 }
 
 impl Poseidon31Channel {

--- a/crates/prover/src/core/channel/poseidon31.rs
+++ b/crates/prover/src/core/channel/poseidon31.rs
@@ -11,18 +11,14 @@ pub struct Poseidon31Channel {
 }
 
 impl Poseidon31Channel {
-    fn draw_base_felts(&mut self) -> [BaseField; 8] {
-        let u32s = self.sponge.squeeze(8);
+    fn draw_base_felts(&mut self) -> [BaseField; 4] {
+        let u32s = self.sponge.squeeze(4);
 
         [
             BaseField::from(u32s[0]),
             BaseField::from(u32s[1]),
             BaseField::from(u32s[2]),
             BaseField::from(u32s[3]),
-            BaseField::from(u32s[4]),
-            BaseField::from(u32s[5]),
-            BaseField::from(u32s[6]),
-            BaseField::from(u32s[7]),
         ]
     }
 }
@@ -64,7 +60,7 @@ impl Channel for Poseidon31Channel {
     }
 
     fn draw_felt(&mut self) -> SecureField {
-        let felts: [BaseField; 8] = self.draw_base_felts();
+        let felts: [BaseField; 4] = self.draw_base_felts();
         SecureField::from_m31_array(felts[..SECURE_EXTENSION_DEGREE].try_into().unwrap())
     }
 

--- a/crates/prover/src/core/channel/poseidon31.rs
+++ b/crates/prover/src/core/channel/poseidon31.rs
@@ -27,7 +27,7 @@ impl Channel for Poseidon31Channel {
     const BYTES_PER_HASH: usize = 32;
 
     fn trailing_zeros(&self) -> u32 {
-        let res = &self.sponge.state[0..4];
+        let res = &self.sponge.state[8..12];
 
         let mut bytes = [0u8; 16];
         bytes[0..4].copy_from_slice(&res[0].to_le_bytes());

--- a/crates/prover/src/core/vcs/poseidon31_hash.rs
+++ b/crates/prover/src/core/vcs/poseidon31_hash.rs
@@ -6,7 +6,7 @@ use crate::core::fields::m31::M31;
 
 #[repr(align(32))]
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct Poseidon31Hash(pub(crate) [M31; 8]);
+pub struct Poseidon31Hash(pub [M31; 8]);
 
 impl From<Poseidon31Hash> for Vec<u8> {
     fn from(value: Poseidon31Hash) -> Vec<u8> {

--- a/crates/prover/src/core/vcs/poseidon31_merkle.rs
+++ b/crates/prover/src/core/vcs/poseidon31_merkle.rs
@@ -64,3 +64,138 @@ impl MerkleChannel for Poseidon31MerkleChannel {
         channel.mix_felts(&[r1, r2]);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use itertools::Itertools;
+    use num_traits::Zero;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    use crate::core::backend::CpuBackend;
+    use crate::core::fields::m31::BaseField;
+    use crate::core::vcs::poseidon31_hash::Poseidon31Hash;
+    use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleHasher;
+    use crate::core::vcs::prover::{MerkleDecommitment, MerkleProver};
+    use crate::core::vcs::verifier::{MerkleVerificationError, MerkleVerifier};
+
+    type TestData = (
+        BTreeMap<u32, Vec<usize>>,
+        MerkleDecommitment<Poseidon31MerkleHasher>,
+        Vec<Vec<BaseField>>,
+        MerkleVerifier<Poseidon31MerkleHasher>,
+    );
+    fn prepare_merkle() -> TestData {
+        const N_COLS: usize = 400;
+        const N_QUERIES: usize = 7;
+        let log_size_range = 6..9;
+
+        let mut rng = SmallRng::seed_from_u64(0);
+        let log_sizes = (0..N_COLS)
+            .map(|_| rng.gen_range(log_size_range.clone()))
+            .collect_vec();
+        let cols = log_sizes
+            .iter()
+            .map(|&log_size| {
+                (0..(1 << log_size))
+                    .map(|_| BaseField::from(rng.gen_range(0..(1 << 30))))
+                    .collect_vec()
+            })
+            .collect_vec();
+        let merkle =
+            MerkleProver::<CpuBackend, Poseidon31MerkleHasher>::commit(cols.iter().collect_vec());
+
+        let mut queries = BTreeMap::<u32, Vec<usize>>::new();
+        for log_size in log_size_range.rev() {
+            let layer_queries = (0..N_QUERIES)
+                .map(|_| rng.gen_range(0..(1 << log_size)))
+                .sorted()
+                .dedup()
+                .collect_vec();
+            queries.insert(log_size, layer_queries);
+        }
+
+        let (values, decommitment) = merkle.decommit(queries.clone(), cols.iter().collect_vec());
+
+        let verifier = MerkleVerifier {
+            root: merkle.root(),
+            column_log_sizes: log_sizes,
+        };
+        (queries, decommitment, values, verifier)
+    }
+
+    #[test]
+    fn test_merkle_success() {
+        let (queries, decommitment, values, verifier) = prepare_merkle();
+
+        verifier.verify(queries, values, decommitment).unwrap();
+    }
+
+    #[test]
+    fn test_merkle_invalid_witness() {
+        let (queries, mut decommitment, values, verifier) = prepare_merkle();
+        decommitment.hash_witness[20] = Poseidon31Hash::default();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::RootMismatch
+        );
+    }
+
+    #[test]
+    fn test_merkle_invalid_value() {
+        let (queries, decommitment, mut values, verifier) = prepare_merkle();
+        values[3][6] = BaseField::zero();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::RootMismatch
+        );
+    }
+
+    #[test]
+    fn test_merkle_witness_too_short() {
+        let (queries, mut decommitment, values, verifier) = prepare_merkle();
+        decommitment.hash_witness.pop();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::WitnessTooShort
+        );
+    }
+
+    #[test]
+    fn test_merkle_column_values_too_long() {
+        let (queries, decommitment, mut values, verifier) = prepare_merkle();
+        values[3].push(BaseField::zero());
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::ColumnValuesTooLong
+        );
+    }
+
+    #[test]
+    fn test_merkle_column_values_too_short() {
+        let (queries, decommitment, mut values, verifier) = prepare_merkle();
+        values[3].pop();
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::ColumnValuesTooShort
+        );
+    }
+
+    #[test]
+    fn test_merkle_witness_too_long() {
+        let (queries, mut decommitment, values, verifier) = prepare_merkle();
+        decommitment.hash_witness.push(Poseidon31Hash::default());
+
+        assert_eq!(
+            verifier.verify(queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::WitnessTooLong
+        );
+    }
+}


### PR DESCRIPTION
Originally mult is in trace, now it is moved into constant. Mult can be in either place, but it is easier to reason it as if it is constant since it only depends on the circuit. 